### PR TITLE
Open_DB: Initialize totlen

### DIFF
--- a/DB.c
+++ b/DB.c
@@ -372,7 +372,7 @@ int Open_DB(char* path, HITS_DB *db)
   else
     { HITS_READ *reads;
       int        i, r, maxlen;
-      int64      totlen;
+      int64      totlen = 0;
 
       nreads = olast-ofirst;
       reads  = (HITS_READ *) Malloc(sizeof(HITS_READ)*(nreads+1),"Allocating Open_DB index");


### PR DESCRIPTION
Variable 'totlen' is uninitialized when used in 'Open_DB'.

See https://github.com/thegenemyers/DALIGNER/blob/master/DB.c#L375
and https://github.com/thegenemyers/DALIGNER/blob/master/DB.c#L385

``` c
      int64      totlen;
…
          totlen += r;
```

```
$ clang -O4 -Wall -Wextra   -c -o DB.o DB.c
clang: warning: -O4 is equivalent to -O3
DB.c:385:11: warning: variable 'totlen' is uninitialized when used here
      [-Wuninitialized]
          totlen += r;
          ^~~~~~
DB.c:375:24: note: initialize the variable 'totlen' to silence this warning
      int64      totlen;
                       ^
                        = 0
1 warning generated.
```
