### PR TITLE
Bug fixes and building aligner libraries

### DIFF
--- a/DB.h
+++ b/DB.h
@@ -57,6 +57,10 @@
 
 #include "QV.h"
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 #define HIDE_FILES          //  Auxiliary DB files start with a . so they are "hidden"
                             //    Undefine if you don't want this
 
@@ -438,5 +442,9 @@ int Read_All_Sequences(HITS_DB *db, int ascii);
   //   to EPLACE) occured and INTERACTIVE is defined.  Otherwise a 0 is returned.
 
 int List_DB_Files(char *path, void actor(char *path, char *extension));
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif // _HITS_DB

--- a/Makefile
+++ b/Makefile
@@ -4,44 +4,71 @@ ALL = daligner HPCdaligner HPCmapper LAsort LAmerge LAsplit LAcat LAshow LAcheck
 
 all: $(ALL)
 
-daligner: daligner.c filter.c filter.h align.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o daligner daligner.c filter.c align.c DB.c QV.c -lpthread -lm
+LIB_ALIGN_HEADERS=align.h DB.h QV.h
 
-HPCdaligner: HPCdaligner.c DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o HPCdaligner HPCdaligner.c DB.c QV.c -lm
+libalign.a: align.c DB.c QV.c ${LIB_ALIGN_HEADERS}
+	$(CC) $(CFLAGS) -c -o align.o align.c
+	$(CC) $(CFLAGS) -c -o DB.o DB.c
+	$(CC) $(CFLAGS) -c -o QV.o QV.c
+	ar r libalign.a align.o DB.o QV.o
+	rm -f align.o DB.o QV.o
 
-HPCmapper: HPCmapper.c DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o HPCmapper HPCmapper.c DB.c QV.c -lm
+libalign.so: align.c DB.c QV.c ${LIB_ALIGN_HEADERS}
+	$(CC) $(CFLAGS) -c -fpic -o align.so align.c
+	$(CC) $(CFLAGS) -c -fpic -o DB.so DB.c
+	$(CC) $(CFLAGS) -c -fpic -o QV.so QV.c
+	$(CC) -shared -o libalign.so align.so DB.so QV.so
+	rm -f align.so DB.so QV.so
 
-LAsort: LAsort.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAsort LAsort.c DB.c QV.c -lm
+daligner: daligner.c filter.c filter.h ${LIB_ALIGN_HEADERS} libalign.a
+	$(CC) $(CFLAGS) -o daligner daligner.c filter.c libalign.a -lpthread -lm 
 
-LAmerge: LAmerge.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAmerge LAmerge.c DB.c QV.c -lm
+HPCdaligner: HPCdaligner.c DB.h QV.h libalign.a
+	$(CC) $(CFLAGS) -o HPCdaligner HPCdaligner.c libalign.a -lm
 
-LAshow: LAshow.c align.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAshow LAshow.c align.c DB.c QV.c -lm
+HPCmapper: HPCmapper.c DB.h QV.h libalign.a
+	$(CC) $(CFLAGS) -o HPCmapper HPCmapper.c libalign.a -lm
 
-LAcat: LAcat.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAcat LAcat.c DB.c QV.c -lm
+LAsort: LAsort.c align.h DB.h QV.h
+	$(CC) $(CFLAGS) -o LAsort LAsort.c libalign.a -lm
 
-LAsplit: LAsplit.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAsplit LAsplit.c DB.c QV.c -lm
+LAmerge: LAmerge.c align.h DB.h QV.h
+	$(CC) $(CFLAGS) -o LAmerge LAmerge.c libalign.a -lm
 
-LAcheck: LAcheck.c align.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAcheck LAcheck.c align.c DB.c QV.c -lm
+LAshow: LAshow.c align.h DB.h QV.h
+	$(CC) $(CFLAGS) -o LAshow LAshow.c libalign.a -lm
 
-LAupgrade.Dec.31.2014: LAupgrade.Dec.31.2014.c align.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAupgrade.Dec.31.2014 LAupgrade.Dec.31.2014.c align.c DB.c QV.c -lm
+LAcat: LAcat.c align.h DB.h QV.h
+	$(CC) $(CFLAGS) -o LAcat LAcat.c libalign.a -lm
+
+LAsplit: LAsplit.c align.h DB.h QV.h
+	$(CC) $(CFLAGS) -o LAsplit LAsplit.c libalign.a -lm
+
+LAcheck: LAcheck.c align.h DB.h QV.h
+	$(CC) $(CFLAGS) -o LAcheck LAcheck.c libalign.a -lm
+
+LAupgrade.Dec.31.2014: LAupgrade.Dec.31.2014.c align.h DB.h QV.h
+	$(CC) $(CFLAGS) -o LAupgrade.Dec.31.2014 LAupgrade.Dec.31.2014.c libalign.a -lm
 
 clean:
 	rm -f $(ALL)
 	rm -fr *.dSYM
 	rm -f LAupgrade.Dec.31.2014
 	rm -f daligner.tar.gz
+	rm -f libalign.a align.o DB.o QV.o
+	rm -f libalign.so align.so DB.so QV.so
 
-install:
+install: $(ALL)
 	cp $(ALL) ~/bin
+
+DESTDIR ?= ${HOME}/daligner
+
+libinstall: libalign.a libalign.so
+	mkdir -p ${DESTDIR}/include
+	mkdir -p ${DESTDIR}/lib
+	cp ${LIB_ALIGN_HEADERS} ${DESTDIR}/include/
+	cp libalign.a libalign.so ${DESTDIR}/lib/
+	chmod 755 ${DESTDIR}/lib/libalign.so
 
 package:
 	make clean

--- a/QV.h
+++ b/QV.h
@@ -52,6 +52,10 @@
 
 #define _QV_COMPRESSOR
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
   //  The defined constant INTERACTIVE (set in DB.h) determines whether an interactive or
   //    batch version of the routines in this library are compiled.  In batch mode, routines
   //    print an error message and exit.  In interactive mode, the routines place the error
@@ -121,5 +125,9 @@ int      Compress_Next_QVentry(FILE *input, FILE *output, QVcoding *coding, int 
   //    error occured.
 
 int      Uncompress_Next_QVentry(FILE *input, char **entry, QVcoding *coding, int rlen);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif // _QV_COMPRESSOR

--- a/align.c
+++ b/align.c
@@ -3565,8 +3565,6 @@ int Compute_Trace_PTS(Alignment *align, Work_Data *ework, int trace_spacing)
       }
     if (tlen <= 1)
       nmax = N;
-    if (points[d-1] > dmax)
-      dmax = points[d-1];
 
     s = (dmax+3)*2*((trace_spacing+nmax+3)*sizeof(int) + sizeof(int *));
 
@@ -3666,8 +3664,6 @@ int Compute_Trace_MID(Alignment *align, Work_Data *ework, int trace_spacing)
       }
     if (tlen <= 1)
       nmax = N;
-    if (points[d-1] > dmax)
-      dmax = points[d-1];
 
     s = (dmax+3)*4*((trace_spacing+nmax+3)*sizeof(int) + sizeof(int *));
 

--- a/align.h
+++ b/align.h
@@ -58,6 +58,10 @@
 
 #define _A_MODULE
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 /*** INTERACTIVE vs BATCH version
 
      The defined constant INTERACTIVE (set in DB.h) determines whether an interactive or
@@ -345,5 +349,9 @@ typedef struct {
   void Decompress_TraceTo16(Overlap *ovl);
 
   int  Check_Trace_Points(Overlap *ovl, int tspace, int verbose, char *fname);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif // _A_MODULE

--- a/align.h
+++ b/align.h
@@ -51,9 +51,6 @@
 
 #include "DB.h"
 
-#define TRACE_XOVR 125   //  If the trace spacing is not more than this value, then can
-                         //    and do compress traces pts to 8-bit unsigned ints
-
 #ifndef _A_MODULE
 
 #define _A_MODULE
@@ -61,6 +58,9 @@
 #if defined(__cplusplus)
 extern "C" {
 #endif
+
+#define TRACE_XOVR 125   //  If the trace spacing is not more than this value, then can
+                         //    and do compress traces pts to 8-bit unsigned ints
 
 /*** INTERACTIVE vs BATCH version
 

--- a/filter.h
+++ b/filter.h
@@ -51,6 +51,10 @@
 #include "DB.h"
 #include "align.h"
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 extern int    BIASED;
 extern int    VERBOSE;
 extern int    MINOVER;
@@ -70,5 +74,9 @@ void Build_Table(HITS_DB *block);
 
 void Match_Filter(char *aname, HITS_DB *ablock, char *bname, HITS_DB *bblock,
                   int self, int comp, Align_Spec *asettings);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif


### PR DESCRIPTION
Hello Gene,

could you please include the changes included in this branch? They include the following:
- a fix in align.c for not accessing the points array at indices which are out of range for that array
- changes to the Makefile for building and installing an aligner library (static and shared), which would make it easier to use the code in other projects
- various smaller things (making the headers usable from C++, moving the definition of TRACE_XOVR inside the include guards in align.h)

Best,
German
