### PR TITLE
Fix apparent MT bug.

### DIFF
--- a/filter.c
+++ b/filter.c
@@ -326,11 +326,13 @@ static Double *lex_sort(int bytes[16], Double *src, Double *trg, Lex_Arg *parmx)
         { x = 0;
           for (i = 0; i < NTHREADS; i++)
             { parmx[i].beg = x;
-              parmx[i].end = x = LEX_zsize*(i+1);
+              if (LEX_zsize*(i+1) <= len) x = LEX_zsize*(i+1);
+              parmx[i].end = x;
               for (j = 0; j < BPOWR; j++)
                 parmx[i].tptr[j] = 0;
             }
           parmx[NTHREADS-1].end = len;
+          //assert(parmx[NTHREADS-1].end >= parmx[NTHREADS-1].beg);
 
           for (j = 0; j < BPOWR; j++)
             { k = (j << NSHIFT);


### PR DESCRIPTION
Herr Myers,

This little bug-fix works well for us with PacBio.

Not really a multi-threading bug, it's just a simple buffer over-run causing one thread to write into the next. The root cause was a logic error in dividing hits into threads when `nhits < NTHREADS`.

The assertion is not needed anymore but would catch the bug.

Fixes PacificBiosciences/DALIGNER#9

~Christopher Dunn
(We met at *Genome in a Bottle/SMRT Informatics Dev. Conference* in Gaithersburg.)