### PR TITLE
Avoid a div-by-0

### DIFF
--- a/LAshow.c
+++ b/LAshow.c
@@ -306,7 +306,7 @@ int main(int argc, char *argv[])
   }
 
   //  Read the file and display selected records
-  
+  if (tspace > 0)
   { int        j;
     uint16    *trace;
     Work_Data *work;


### PR DESCRIPTION
This avoids a divide-by-zero at [lines 352 and 357](https://github.com/thegenemyers/DALIGNER/commit/d11a80f0754da4ee04a230214b58ff2e928d7be0#diff-aaeef5966630239b0431a8d99d50714cR316).

We are not certain of this one. Would it be better to test for `novl > 0`? Could you explain briefly the meaning of the `tspace` parameter?

Also, here are some warnings:
```
filter.c: In function 'tuple_thread':
filter.c:434:13: warning: 'q' may be used uninitialized in this function [-Wmaybe-uninitialized]
           s += (q+1);
             ^
filter.c: In function 'biased_tuple_thread':
filter.c:538:13: warning: 'q' may be used uninitialized in this function [-Wmaybe-uninitialized]
           s += (q+1);
```