### PR TITLE
Fix memcpy to overlapping memory

### DIFF
--- a/LAmerge.c
+++ b/LAmerge.c
@@ -168,7 +168,7 @@ static void ovl_reload(IO_block *in, int64 bsize)
 
   remains = in->top - in->ptr;
   if (remains > 0)
-    memcpy(in->block, in->ptr, remains);
+    memmove(in->block, in->ptr, remains);
   in->ptr  = in->block;
   in->top  = in->block + remains;
   in->top += fread(in->top,1,bsize-remains,in->stream);


### PR DESCRIPTION
fixes PacificBiosciences/DALIGNER#24

Eliminates valgrind warning and fixes `Trace point sum != aligned interval` with all compiler versions. 

Maybe there is a real fix that is better, but this at least fixes the error.