### PR TITLE
Honor standard compiler/linker flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,34 @@
 DEST_DIR = ~/bin
 
-CFLAGS = -O3 -Wall -Wextra -Wno-unused-result -fno-strict-aliasing
+CFLAGS += -O3 -Wall -Wextra -Wno-unused-result -fno-strict-aliasing
+LDLIBS = -lm
 
 ALL = daligner HPC.daligner LAsort LAmerge LAsplit LAcat LAshow LAdump LAcheck LAindex
 
 all: $(ALL)
 
+daligner: LDLIBS += -lpthread
 daligner: daligner.c filter.c filter.h align.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o daligner daligner.c filter.c align.c DB.c QV.c -lpthread -lm
 
 HPC.daligner: HPC.daligner.c DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o HPC.daligner HPC.daligner.c DB.c QV.c -lm
 
 LAsort: LAsort.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAsort LAsort.c DB.c QV.c -lm
 
 LAmerge: LAmerge.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAmerge LAmerge.c DB.c QV.c -lm
 
 LAshow: LAshow.c align.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAshow LAshow.c align.c DB.c QV.c -lm
 
 LAdump: LAdump.c align.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAdump LAdump.c align.c DB.c QV.c -lm
 
 LAcat: LAcat.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAcat LAcat.c DB.c QV.c -lm
 
 LAsplit: LAsplit.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAsplit LAsplit.c DB.c QV.c -lm
 
 LAcheck: LAcheck.c align.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAcheck LAcheck.c align.c DB.c QV.c -lm
 
 LAupgrade.Dec.31.2014: LAupgrade.Dec.31.2014.c align.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAupgrade.Dec.31.2014 LAupgrade.Dec.31.2014.c align.c DB.c QV.c -lm
 
 LAindex: LAindex.c align.c align.h DB.c DB.h QV.c QV.h
-	gcc $(CFLAGS) -o LAindex LAindex.c align.c DB.c QV.c -lm
 
 clean:
 	rm -f $(ALL)


### PR DESCRIPTION
This allows for passing additional compiler/linker flags from
the command line by supporting standard variables like CPPFLAGS,
CFLAGS, and LDFLAGS. It also saves a good amount of redundant typing.

This PR replaces #38 since I'm using the Debian fork as the source rather than my personal one.