### PR TITLE
fixed: missing .las extension when removing lv1 .las files

### DIFF
--- a/HPC.daligner.c
+++ b/HPC.daligner.c
@@ -1218,7 +1218,7 @@ void mapper_script(int argc, char *argv[])
                           { fprintf(out," %s",root2);
                             if (useblock2)
                               fprintf(out,".%d",j);
-                            fprintf(out,".%s.%d",root1,k);
+                            fprintf(out,".%s.%d.las",root1,k);
                           }
                         else
                           fprintf(out," L%d.%d.%d.las",i,j,k);


### PR DESCRIPTION
minimally tested: compiles, and produces correct `rm` command