### PR TITLE
Fix invalid memory access

### DIFF
--- a/LAdump.c
+++ b/LAdump.c
@@ -415,8 +415,6 @@ int main(int argc, char *argv[])
        //  Read it in
 
       { Read_Overlap(input,ovl);
-        ovl->path.trace = (void *) trace;
-        Read_Trace(input,ovl,tbytes);
 
         //  Determine if it should be displayed
 
@@ -442,7 +440,14 @@ int main(int argc, char *argv[])
               }
           }
         if (!in)
+        {
+          Skip_Trace(input,ovl,tbytes);
+
           continue;
+        }
+
+        ovl->path.trace = (void *) trace;
+        Read_Trace(input,ovl,tbytes);
 
         //  If -o check display only overlaps
 

--- a/align.c
+++ b/align.c
@@ -3052,6 +3052,14 @@ int Read_Trace(FILE *input, Overlap *ovl, int tbytes)
   return (0);
 }
 
+int Skip_Trace(FILE *input, Overlap *ovl, int tbytes)
+{ if (tbytes > 0 && ovl->path.tlen > 0)
+    { if (fseek(input, tbytes*ovl->path.tlen, SEEK_CUR) != 0)
+        return (1);
+    }
+  return (0);
+}
+
 int Write_Overlap(FILE *output, Overlap *ovl, int tbytes)
 { if (fwrite( ((char *) ovl) + PtrSize, OvlIOSize, 1, output) != 1)
     return (1);

--- a/align.h
+++ b/align.h
@@ -365,6 +365,7 @@ typedef struct {
 
   int Read_Overlap(FILE *input, Overlap *ovl);
   int Read_Trace(FILE *innput, Overlap *ovl, int tbytes);
+  int Skip_Trace(FILE *innput, Overlap *ovl, int tbytes);
 
   int  Write_Overlap(FILE *output, Overlap *ovl, int tbytes);
   void Print_Overlap(FILE *output, Overlap *ovl, int tbytes, int indent);


### PR DESCRIPTION
If selecting a subset of reads on the CLI it could happen that the trace buffer would overflow. This is prevented by not reading the trace of "unrequested" alignments but rather skipping them using `fseek`.