### PR TITLE
ONElib.c: fix missing include.

### DIFF
--- a/ONElib.c
+++ b/ONElib.c
@@ -16,8 +16,10 @@
  *
  ****************************************************************************************/
 
+#define _GNU_SOURCE
 #include <sys/errno.h>
 #include <sys/types.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/resource.h>


### PR DESCRIPTION
As first identified in [Debian bug #1066534], DALIGNER fails to build from source when compiled with -Werror=implicit-function-declaration. This change ensures the definition of vasprintf is appropriately loaded from the standard C library with appropriate GNU extensions.

[Debian bug #1066534]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1066534