### PR TITLE
ONE2LA.c: fix build failure with gcc 14.

### DIFF
--- a/ONE2LA.c
+++ b/ONE2LA.c
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
 
   OneFile   *file1;
   OneSchema *schema;
-  int64     *list;
+  I64       *list;
   char      *string, *command;
 
   int t, i, j, k;


### PR DESCRIPTION
Since gcc 14, incompatible pointer type casting is now an error.  In the case of daligner, the build results in the following errors:

	ONE2LA.c:135:13: error: assignment to ‘int64 *’ {aka ‘long long int *’} from incompatible pointer type ‘I64 *’ {aka ‘long int *’} [-Wincompatible-pointer-types]
	  135 |       list  = oneIntList(file1);
	      |             ^
	ONE2LA.c:202:20: error: assignment to ‘int64 *’ {aka ‘long long int *’} from incompatible pointer type ‘I64 *’ {aka ‘long int *’} [-Wincompatible-pointer-types]
	  202 |               list = oneIntList(file1);
	      |                    ^
	ONE2LA.c:210:20: error: assignment to ‘int64 *’ {aka ‘long long int *’} from incompatible pointer type ‘I64 *’ {aka ‘long int *’} [-Wincompatible-pointer-types]
	  210 |               list = oneIntList(file1);
	      |                    ^
	ONE2LA.c:220:20: error: assignment to ‘int64 *’ {aka ‘long long int *’} from incompatible pointer type ‘I64 *’ {aka ‘long int *’} [-Wincompatible-pointer-types]
	  220 |               list = oneIntList(file1);
	      |                    ^
	ONE2LA.c:227:20: error: assignment to ‘int64 *’ {aka ‘long long int *’} from incompatible pointer type ‘I64 *’ {aka ‘long int *’} [-Wincompatible-pointer-types]
	  227 |               list = oneIntList(file1);
	      |                    ^

Typing the list the same way as the return type of the oneIntList function is one possible way of resolving the issue.

This has initially been reported on [Debian bug #1074900] by Matthias Klose.

[Debian bug #1074900]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1074900